### PR TITLE
feat : 최근 상품 코멘트 조회 api

### DIFF
--- a/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/ProductCommentController.kt
+++ b/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/ProductCommentController.kt
@@ -6,6 +6,7 @@ import com.yapp.cvs.api.comment.dto.ProductCommentDetailDTO
 import com.yapp.cvs.api.comment.dto.ProductCommentSearchDTO
 import com.yapp.cvs.api.common.dto.OffsetPageDTO
 import com.yapp.cvs.domain.comment.application.ProductCommentProcessor
+import com.yapp.cvs.domain.comment.vo.ProductCommentRequestVO
 import com.yapp.cvs.domain.like.application.ProductLikeProcessor
 import com.yapp.cvs.domain.like.vo.ProductLikeRequestVO
 import io.swagger.v3.oas.annotations.Operation
@@ -27,37 +28,41 @@ class ProductCommentController(
 
     @GetMapping("/comments")
     @Operation(summary = "해당 상품에 작성된 평가 코멘트를 최대 10개 가져옵니다.")
-    fun getRecentProductComments(): List<ProductCommentDetailDTO> {
-        val result = productCommentProcessor.getRecentCommentDetails(memberId)
-        return result.map { ProductCommentDetailDTO.from(it) }
+    fun getRecentProductComments(@ParameterObject productCommentSearchDTO: ProductCommentSearchDTO): OffsetPageDTO<ProductCommentDetailDTO> {
+        val requestVO = productCommentSearchDTO.toVO()
+        val result = productCommentProcessor.getCommentDetails(memberId, requestVO)
+        return OffsetPageDTO(result.lastId, result.content.map { ProductCommentDetailDTO.from(it) })
     }
 
     @GetMapping("/{productId}/comments")
-    @Operation(description = "해당 상품에 작성된 평가 코멘트를 조건만큼 가져옵니다.")
+    @Operation(summary = "해당 상품에 작성된 평가 코멘트를 조건만큼 가져옵니다.")
     fun getProductComments(@PathVariable productId: Long,
                            @ParameterObject productCommentSearchDTO: ProductCommentSearchDTO): OffsetPageDTO<ProductCommentDetailDTO> {
-        val result = productCommentProcessor.getCommentDetails(productId, memberId, productCommentSearchDTO.toVO())
+        val requestVO = productCommentSearchDTO.toVO(productId)
+        val result = productCommentProcessor.getCommentDetails(memberId, requestVO)
         return OffsetPageDTO(result.lastId, result.content.map { ProductCommentDetailDTO.from(it) })
     }
 
     @PostMapping("/{productId}/comment/write")
-    @Operation(description = "상품에 대한 평가 코멘트를 작성합니다.")
+    @Operation(summary = "상품에 대한 평가 코멘트를 작성합니다.")
     fun writeComment(@PathVariable productId: Long,
                      @RequestBody productCommentContentDTO: ProductCommentContentDTO): ProductCommentDTO {
-        val comment = productCommentProcessor.createComment(productId, memberId, productCommentContentDTO.content)
+        val requestVO = ProductCommentRequestVO(productId, memberId)
+        val comment = productCommentProcessor.createComment(requestVO, productCommentContentDTO.content)
         return ProductCommentDTO.from(comment)
     }
 
     @PostMapping("/{productId}/comment/edit")
-    @Operation(description = "상품에 대한 평가 코멘트를 수정합니다.")
+    @Operation(summary = "상품에 대한 평가 코멘트를 수정합니다.")
     fun updateComment(@PathVariable productId: Long,
                       @RequestBody productCommentContentDTO: ProductCommentContentDTO): ProductCommentDTO {
-        val comment = productCommentProcessor.updateComment(productId, memberId, productCommentContentDTO.content)
+        val requestVO = ProductCommentRequestVO(productId, memberId)
+        val comment = productCommentProcessor.updateComment(requestVO, productCommentContentDTO.content)
         return ProductCommentDTO.from(comment)
     }
 
     @PostMapping("/{productId}/comment/delete")
-    @Operation(description = "상품에 대한 평가 코멘트를 삭제합니다.")
+    @Operation(summary = "상품에 대한 평가 코멘트를 삭제합니다.")
     fun deleteComment(@PathVariable productId: Long) {
         productLikeProcessor.cancelEvaluation(ProductLikeRequestVO(productId = productId, memberId = memberId))
     }

--- a/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/ProductCommentController.kt
+++ b/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/ProductCommentController.kt
@@ -24,6 +24,13 @@ class ProductCommentController(
 ) {
     private val memberId = 1L //TODO : security context 에서 memberId 가져오기
 
+    @GetMapping("/comments")
+    @Operation(summary = "해당 상품에 작성된 평가 코멘트를 최대 10개 가져옵니다.")
+    fun getRecentProductComments(): List<ProductCommentDetailDTO> {
+        val result = productCommentProcessor.getRecentCommentDetails(memberId)
+        return result.map { ProductCommentDetailDTO.from(it) }
+    }
+
     @GetMapping("/{productId}/comments")
     @Operation(description = "해당 상품에 작성된 평가 코멘트를 조건만큼 가져옵니다.")
     fun getProductComments(@PathVariable productId: Long,

--- a/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/dto/ProductCommentDetailDTO.kt
+++ b/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/dto/ProductCommentDetailDTO.kt
@@ -1,34 +1,32 @@
 package com.yapp.cvs.api.comment.dto
 
+import com.yapp.cvs.api.member.dto.MemberDTO
 import com.yapp.cvs.domain.comment.vo.ProductCommentDetailVO
 import com.yapp.cvs.domain.enums.ProductLikeType
+import com.yapp.cvs.domain.member.vo.MemberVO
 import java.time.LocalDateTime
 
 data class ProductCommentDetailDTO(
         val productCommentId: Long,
+        val productId: Long,
+        val member: MemberDTO?,
+        val isOwner: Boolean,
+        val likeType: ProductLikeType,
         val content: String,
         val commentLikeCount: Long,
-        val isOwner: Boolean,
         val createdAt: LocalDateTime,
-        val likeType: ProductLikeType,
-
-        val memberId: Long,
-        val nickname: String,
-
-        val productId: Long
 ) {
     companion object {
         fun from(productCommentDetailVO: ProductCommentDetailVO): ProductCommentDetailDTO {
             return ProductCommentDetailDTO(
                     productCommentId = productCommentDetailVO.productCommentId,
+                    productId = productCommentDetailVO.productId,
+                    member = productCommentDetailVO.memberVO ?.let { MemberDTO.from(it) },
+                    isOwner = productCommentDetailVO.isOwner,
+                    likeType = productCommentDetailVO.likeType,
                     content = productCommentDetailVO.content,
                     commentLikeCount = productCommentDetailVO.commentLikeCount,
-                    isOwner = productCommentDetailVO.isOwner,
-                    createdAt = productCommentDetailVO.createdAt,
-                    likeType = productCommentDetailVO.likeType ?: ProductLikeType.NONE,
-                    memberId = productCommentDetailVO.memberId,
-                    nickname = productCommentDetailVO.nickname,
-                    productId = productCommentDetailVO.productId
+                    createdAt = productCommentDetailVO.createdAt
             )
         }
     }

--- a/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/dto/ProductCommentDetailDTO.kt
+++ b/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/dto/ProductCommentDetailDTO.kt
@@ -3,7 +3,6 @@ package com.yapp.cvs.api.comment.dto
 import com.yapp.cvs.api.member.dto.MemberDTO
 import com.yapp.cvs.domain.comment.vo.ProductCommentDetailVO
 import com.yapp.cvs.domain.enums.ProductLikeType
-import com.yapp.cvs.domain.member.vo.MemberVO
 import java.time.LocalDateTime
 
 data class ProductCommentDetailDTO(
@@ -21,7 +20,7 @@ data class ProductCommentDetailDTO(
             return ProductCommentDetailDTO(
                     productCommentId = productCommentDetailVO.productCommentId,
                     productId = productCommentDetailVO.productId,
-                    member = productCommentDetailVO.memberVO ?.let { MemberDTO.from(it) },
+                    member = MemberDTO.from(productCommentDetailVO.memberVO),
                     isOwner = productCommentDetailVO.isOwner,
                     likeType = productCommentDetailVO.likeType,
                     content = productCommentDetailVO.content,

--- a/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/dto/ProductCommentSearchDTO.kt
+++ b/cvs-api/src/main/kotlin/com/yapp/cvs/api/comment/dto/ProductCommentSearchDTO.kt
@@ -9,11 +9,12 @@ data class ProductCommentSearchDTO(
         val offsetProductCommentId: Long? = null,
         val orderBy: ProductCommentOrderType = ProductCommentOrderType.RECENT
 ) {
-    fun toVO(): ProductCommentSearchVO {
+    fun toVO(productId: Long ?= null): ProductCommentSearchVO {
         return ProductCommentSearchVO(
                 pageSize = pageSize,
                 offsetProductCommentId = offsetProductCommentId,
-                orderBy = orderBy
+                orderBy = orderBy,
+                productId = productId
         )
     }
 }

--- a/cvs-api/src/main/kotlin/com/yapp/cvs/api/member/dto/MemberDTO.kt
+++ b/cvs-api/src/main/kotlin/com/yapp/cvs/api/member/dto/MemberDTO.kt
@@ -1,0 +1,17 @@
+package com.yapp.cvs.api.member.dto
+
+import com.yapp.cvs.domain.member.vo.MemberVO
+
+data class MemberDTO (
+    val memberId: Long,
+    val nickname: String
+) {
+    companion object {
+        fun from(memberVO: MemberVO): MemberDTO {
+            return MemberDTO(
+                    memberId = memberVO.memberId,
+                    nickname = memberVO.nickname
+            )
+        }
+    }
+}

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentProcessor.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentProcessor.kt
@@ -2,6 +2,7 @@ package com.yapp.cvs.domain.comment.application
 
 import com.yapp.cvs.domain.base.vo.OffsetPageVO
 import com.yapp.cvs.domain.comment.vo.ProductCommentDetailVO
+import com.yapp.cvs.domain.comment.vo.ProductCommentRequestVO
 import com.yapp.cvs.domain.comment.vo.ProductCommentSearchVO
 import com.yapp.cvs.domain.comment.vo.ProductCommentVO
 import com.yapp.cvs.domain.enums.DistributedLockType
@@ -14,29 +15,20 @@ import org.springframework.transaction.annotation.Transactional
 class ProductCommentProcessor(
         private val productCommentService: ProductCommentService
 ) {
-    fun getRecentCommentDetails(memberId: Long): List<ProductCommentDetailVO> {
-        val result = productCommentService.findRecentProductComments()
-        result.filter { it.memberId == memberId }
-                .forEach { it.isOwner = true }
-        return result
+    fun getCommentDetails(memberId: Long, productCommentSearchVO: ProductCommentSearchVO): OffsetPageVO<ProductCommentDetailVO> {
+        val result = productCommentService.findProductCommentsPage(productCommentSearchVO)
+        return OffsetPageVO(result.lastOrNull()?.productCommentId, result.map { ProductCommentDetailVO.of(it, memberId) } )
     }
 
-    fun getCommentDetails(productId: Long, memberId: Long, productCommentSearchVO: ProductCommentSearchVO): OffsetPageVO<ProductCommentDetailVO> {
-        val result = productCommentService.findProductCommentsPage(productId, productCommentSearchVO)
-        result.filter { it.memberId == memberId }
-                .forEach { it.isOwner = true }
-        return OffsetPageVO(result.lastOrNull()?.productCommentId, result)
-    }
-
-    @DistributedLock(DistributedLockType.MEMBER_PRODUCT, ["productId", "memberId"])
-    fun createComment(productId: Long, memberId: Long, content: String): ProductCommentVO {
-        val commentHistory = productCommentService.write(productId, memberId, content)
+    @DistributedLock(DistributedLockType.MEMBER_PRODUCT, ["productCommentRequestVO"])
+    fun createComment(productCommentRequestVO: ProductCommentRequestVO, content: String): ProductCommentVO {
+        val commentHistory = productCommentService.write(productCommentRequestVO.memberProductMappingKey, content)
         return ProductCommentVO.from(commentHistory)
     }
 
-    @DistributedLock(DistributedLockType.MEMBER_PRODUCT, ["productId", "memberId"])
-    fun updateComment(productId: Long, memberId: Long, content: String): ProductCommentVO {
-        val commentHistory = productCommentService.update(productId, memberId, content)
+    @DistributedLock(DistributedLockType.MEMBER_PRODUCT, ["productCommentRequestVO"])
+    fun updateComment(productCommentRequestVO: ProductCommentRequestVO, content: String): ProductCommentVO {
+        val commentHistory = productCommentService.update(productCommentRequestVO.memberProductMappingKey, content)
         return ProductCommentVO.from(commentHistory)
     }
 }

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentProcessor.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentProcessor.kt
@@ -17,7 +17,9 @@ class ProductCommentProcessor(
 ) {
     fun getCommentDetails(memberId: Long, productCommentSearchVO: ProductCommentSearchVO): OffsetPageVO<ProductCommentDetailVO> {
         val result = productCommentService.findProductCommentsPage(productCommentSearchVO)
-        return OffsetPageVO(result.lastOrNull()?.productCommentId, result.map { ProductCommentDetailVO.of(it, memberId) } )
+        result.filter { it.memberVO.memberId == memberId }
+                .forEach { it.isOwner = true }
+        return OffsetPageVO(result.lastOrNull()?.productCommentId, result)
     }
 
     @DistributedLock(DistributedLockType.MEMBER_PRODUCT, ["productCommentRequestVO"])

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentProcessor.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentProcessor.kt
@@ -5,9 +5,6 @@ import com.yapp.cvs.domain.comment.vo.ProductCommentDetailVO
 import com.yapp.cvs.domain.comment.vo.ProductCommentSearchVO
 import com.yapp.cvs.domain.comment.vo.ProductCommentVO
 import com.yapp.cvs.domain.enums.DistributedLockType
-import com.yapp.cvs.domain.enums.ProductLikeType
-import com.yapp.cvs.domain.like.application.ProductLikeHistoryService
-import com.yapp.cvs.domain.like.application.ProductLikeSummaryService
 import com.yapp.cvs.infrastructure.redis.lock.DistributedLock
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +14,13 @@ import org.springframework.transaction.annotation.Transactional
 class ProductCommentProcessor(
         private val productCommentService: ProductCommentService
 ) {
+    fun getRecentCommentDetails(memberId: Long): List<ProductCommentDetailVO> {
+        val result = productCommentService.findRecentProductComments()
+        result.filter { it.memberId == memberId }
+                .forEach { it.isOwner = true }
+        return result
+    }
+
     fun getCommentDetails(productId: Long, memberId: Long, productCommentSearchVO: ProductCommentSearchVO): OffsetPageVO<ProductCommentDetailVO> {
         val result = productCommentService.findProductCommentsPage(productId, productCommentSearchVO)
         result.filter { it.memberId == memberId }

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentService.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentService.kt
@@ -12,6 +12,10 @@ import org.springframework.stereotype.Service
 class ProductCommentService(
         val productCommentRepository: ProductCommentRepository
 ) {
+    fun findRecentProductComments(): List<ProductCommentDetailVO> {
+        return productCommentRepository.findRecentComments()
+    }
+
     fun findProductCommentsPage(productId: Long, productCommentSearchVO: ProductCommentSearchVO): List<ProductCommentDetailVO> {
         return productCommentRepository.findAllByProductIdAndPageOffset(productId, productCommentSearchVO)
     }

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentService.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/application/ProductCommentService.kt
@@ -2,6 +2,7 @@ package com.yapp.cvs.domain.comment.application
 
 import com.yapp.cvs.domain.comment.entity.ProductComment
 import com.yapp.cvs.domain.comment.repository.ProductCommentRepository
+import com.yapp.cvs.domain.comment.vo.ProductCommentDetailVO
 import com.yapp.cvs.domain.comment.vo.ProductCommentSearchVO
 import com.yapp.cvs.domain.like.entity.MemberProductMappingKey
 import com.yapp.cvs.exception.BadRequestException
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Service
 class ProductCommentService(
         val productCommentRepository: ProductCommentRepository
 ) {
-    fun findProductCommentsPage(productCommentSearchVO: ProductCommentSearchVO): List<ProductComment> {
+    fun findProductCommentsPage(productCommentSearchVO: ProductCommentSearchVO): List<ProductCommentDetailVO> {
         return productCommentRepository.findAllByCondition(productCommentSearchVO)
     }
 

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/entity/ProductComment.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/entity/ProductComment.kt
@@ -1,10 +1,19 @@
 package com.yapp.cvs.domain.comment.entity
 
 import com.yapp.cvs.domain.base.BaseEntity
+import com.yapp.cvs.domain.like.entity.MemberProductLikeMapping
+import com.yapp.cvs.domain.member.entity.Member
+import java.io.Serializable
 import javax.persistence.Entity
+import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.JoinColumns
+import javax.persistence.ManyToOne
+import javax.persistence.OneToMany
+import javax.persistence.OneToOne
 import javax.persistence.Table
 
 @Entity
@@ -21,4 +30,13 @@ class ProductComment(
         var content: String,
 
         var valid: Boolean = true,
-): BaseEntity()
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "memberId", referencedColumnName = "memberId", insertable = false, updatable = false)
+        val member: Member? = null,
+
+        @OneToMany(fetch = FetchType.LAZY)
+        @JoinColumn(name = "productId", referencedColumnName = "productId", insertable = false, updatable = false)
+        @JoinColumn(name = "memberId", referencedColumnName = "memberId", insertable = false, updatable = false)
+        val memberProductLikeMappingList: Set<MemberProductLikeMapping> = setOf()
+): BaseEntity(), Serializable

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/entity/ProductComment.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/entity/ProductComment.kt
@@ -30,13 +30,4 @@ class ProductComment(
         var content: String,
 
         var valid: Boolean = true,
-
-        @ManyToOne(fetch = FetchType.LAZY)
-        @JoinColumn(name = "memberId", referencedColumnName = "memberId", insertable = false, updatable = false)
-        val member: Member? = null,
-
-        @OneToMany(fetch = FetchType.LAZY)
-        @JoinColumn(name = "productId", referencedColumnName = "productId", insertable = false, updatable = false)
-        @JoinColumn(name = "memberId", referencedColumnName = "memberId", insertable = false, updatable = false)
-        val memberProductLikeMappingList: Set<MemberProductLikeMapping> = setOf()
 ): BaseEntity(), Serializable

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/ProductCommentRepository.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/ProductCommentRepository.kt
@@ -13,5 +13,6 @@ interface ProductCommentRepository : JpaRepository<ProductComment, Long>, Produc
 
 interface ProductCommentCustom {
     fun findLatestByProductIdAndMemberId(productId: Long, memberId: Long): ProductComment?
+    fun findRecentComments(): List<ProductCommentDetailVO>
     fun findAllByProductIdAndPageOffset(productId: Long, productCommentSearchVO: ProductCommentSearchVO): List<ProductCommentDetailVO>
 }

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/ProductCommentRepository.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/ProductCommentRepository.kt
@@ -6,13 +6,10 @@ import com.yapp.cvs.domain.comment.vo.ProductCommentSearchVO
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ProductCommentRepository : JpaRepository<ProductComment, Long>, ProductCommentCustom {
-    fun findByProductIdAndMemberIdAndValidTrue(productId: Long, memberId: Long): ProductComment?
     fun existsByProductIdAndMemberIdAndValidTrue(productId: Long, memberId: Long): Boolean
-    fun deleteByProductIdAndMemberId(productId: Long, memberId: Long)
 }
 
 interface ProductCommentCustom {
     fun findLatestByProductIdAndMemberId(productId: Long, memberId: Long): ProductComment?
-    fun findRecentComments(): List<ProductCommentDetailVO>
-    fun findAllByProductIdAndPageOffset(productId: Long, productCommentSearchVO: ProductCommentSearchVO): List<ProductCommentDetailVO>
+    fun findAllByCondition(productCommentSearchVO: ProductCommentSearchVO): List<ProductComment>
 }

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/ProductCommentRepository.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/ProductCommentRepository.kt
@@ -11,5 +11,5 @@ interface ProductCommentRepository : JpaRepository<ProductComment, Long>, Produc
 
 interface ProductCommentCustom {
     fun findLatestByProductIdAndMemberId(productId: Long, memberId: Long): ProductComment?
-    fun findAllByCondition(productCommentSearchVO: ProductCommentSearchVO): List<ProductComment>
+    fun findAllByCondition(productCommentSearchVO: ProductCommentSearchVO): List<ProductCommentDetailVO>
 }

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/impl/ProductCommentRepositoryImpl.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/impl/ProductCommentRepositoryImpl.kt
@@ -27,6 +27,22 @@ class ProductCommentRepositoryImpl: QuerydslRepositorySupport(ProductComment::cl
                 .fetchFirst()
     }
 
+    override fun findRecentComments(): List<ProductCommentDetailVO> {
+        return from(productComment)
+                .leftJoin(member)
+                .on(productComment.memberId.eq(member.memberId))
+                .leftJoin(memberProductLikeMapping)
+                .on(
+                        productComment.productId.eq(memberProductLikeMapping.productId),
+                        productComment.memberId.eq(memberProductLikeMapping.memberId)
+                )
+                .where(productComment.valid.isTrue)
+                .orderBy(productComment.productCommentId.desc())
+                .select(productDetailVOProjection())
+                .limit(10)
+                .fetch()
+    }
+
     override fun findAllByProductIdAndPageOffset(productId: Long,
                                                  productCommentSearchVO: ProductCommentSearchVO): List<ProductCommentDetailVO> {
         val size = productCommentSearchVO.pageSize

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentDetailVO.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentDetailVO.kt
@@ -1,17 +1,34 @@
 package com.yapp.cvs.domain.comment.vo
 
+import com.yapp.cvs.domain.comment.entity.ProductComment
 import com.yapp.cvs.domain.enums.ProductLikeType
+import com.yapp.cvs.domain.extension.ifNotNull
+import com.yapp.cvs.domain.member.vo.MemberVO
 import java.time.LocalDateTime
 
-data class ProductCommentDetailVO(
+class ProductCommentDetailVO(
         val productCommentId: Long,
         val content: String,
         val commentLikeCount: Long,
         val createdAt: LocalDateTime,
-        val likeType: ProductLikeType ?= ProductLikeType.NONE,
+        val likeType: ProductLikeType,
         val productId: Long,
 
-        val memberId: Long,
-        val nickname: String,
-        var isOwner: Boolean = false
-)
+        val memberVO: MemberVO?,
+        val isOwner: Boolean
+) {
+    companion object {
+        fun of(productComment: ProductComment, memberId: Long): ProductCommentDetailVO {
+            return ProductCommentDetailVO(
+                    productCommentId = productComment.productCommentId!!,
+                    content = productComment.content,
+                    commentLikeCount = 10L, //todo : 좋아요 카운트 필요
+                    createdAt = productComment.createdAt,
+                    likeType = productComment.memberProductLikeMappingList.firstOrNull()?.likeType ?: ProductLikeType.NONE,
+                    productId = productComment.productId,
+                    memberVO = productComment.member.ifNotNull { MemberVO.from(it) },
+                    isOwner = productComment.member?.memberId!! == memberId
+            )
+        }
+    }
+}

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentDetailVO.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentDetailVO.kt
@@ -1,34 +1,19 @@
 package com.yapp.cvs.domain.comment.vo
 
-import com.yapp.cvs.domain.comment.entity.ProductComment
 import com.yapp.cvs.domain.enums.ProductLikeType
-import com.yapp.cvs.domain.extension.ifNotNull
 import com.yapp.cvs.domain.member.vo.MemberVO
 import java.time.LocalDateTime
 
-class ProductCommentDetailVO(
+data class ProductCommentDetailVO(
         val productCommentId: Long,
         val content: String,
         val commentLikeCount: Long,
         val createdAt: LocalDateTime,
         val likeType: ProductLikeType,
         val productId: Long,
-
-        val memberVO: MemberVO?,
-        val isOwner: Boolean
+        private val memberId: Long,
+        private val nickname: String,
+        var isOwner: Boolean
 ) {
-    companion object {
-        fun of(productComment: ProductComment, memberId: Long): ProductCommentDetailVO {
-            return ProductCommentDetailVO(
-                    productCommentId = productComment.productCommentId!!,
-                    content = productComment.content,
-                    commentLikeCount = 10L, //todo : 좋아요 카운트 필요
-                    createdAt = productComment.createdAt,
-                    likeType = productComment.memberProductLikeMappingList.firstOrNull()?.likeType ?: ProductLikeType.NONE,
-                    productId = productComment.productId,
-                    memberVO = productComment.member.ifNotNull { MemberVO.from(it) },
-                    isOwner = productComment.member?.memberId!! == memberId
-            )
-        }
-    }
+    val memberVO = MemberVO(memberId, nickname)
 }

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentRequestVO.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentRequestVO.kt
@@ -1,0 +1,13 @@
+package com.yapp.cvs.domain.comment.vo
+
+import com.yapp.cvs.domain.like.entity.MemberProductMappingKey
+
+class ProductCommentRequestVO(
+    val productId: Long,
+    val memberId: Long
+) {
+    val memberProductMappingKey: MemberProductMappingKey = MemberProductMappingKey(
+        productId = productId,
+        memberId = memberId
+    )
+}

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentSearchVO.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentSearchVO.kt
@@ -6,4 +6,5 @@ data class ProductCommentSearchVO(
         val pageSize: Long,
         val offsetProductCommentId: Long?,
         val orderBy: ProductCommentOrderType,
+        val productId: Long?
 )

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/like/application/ProductLikeProcessor.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/like/application/ProductLikeProcessor.kt
@@ -60,7 +60,7 @@ class ProductLikeProcessor(
     fun dislikeProduct(productLikeRequestVO: ProductLikeRequestVO): ProductScoreVO {
         val memberProductLikeMapping = memberProductLikeMappingService
             .findByMemberProductLike(productLikeRequestVO.memberProductMappingKey)
-            ?.also { if(it.likeType.isLike()) throw BadRequestException("이미 싫어요 한 상품입니다.") }
+            ?.also { if(it.likeType.isDisLike()) throw BadRequestException("이미 싫어요 한 상품입니다.") }
             ?.apply { likeType = ProductLikeType.DISLIKE }
             ?: MemberProductLikeMapping.dislike(productLikeRequestVO.memberProductMappingKey)
 

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/like/entity/MemberProductLikeMapping.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/like/entity/MemberProductLikeMapping.kt
@@ -2,6 +2,7 @@ package com.yapp.cvs.domain.like.entity
 
 import com.yapp.cvs.domain.base.BaseEntity
 import com.yapp.cvs.domain.enums.ProductLikeType
+import java.io.Serializable
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
@@ -23,7 +24,7 @@ class MemberProductLikeMapping(
 
     @Enumerated(EnumType.STRING)
     var likeType: ProductLikeType
-): BaseEntity() {
+): BaseEntity(), Serializable {
 
     companion object {
         fun like(memberProductMappingKey: MemberProductMappingKey): MemberProductLikeMapping{

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/like/entity/ProductLikeSummary.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/like/entity/ProductLikeSummary.kt
@@ -7,7 +7,7 @@ import javax.persistence.*
 import kotlin.math.max
 
 @Entity
-@Table(name = "product_like_summarys")
+@Table(name = "product_like_summaries")
 class ProductLikeSummary(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/member/vo/MemberVO.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/member/vo/MemberVO.kt
@@ -1,0 +1,17 @@
+package com.yapp.cvs.domain.member.vo
+
+import com.yapp.cvs.domain.member.entity.Member
+
+data class MemberVO(
+        val memberId: Long,
+        val nickname: String
+) {
+    companion object {
+        fun from(member: Member): MemberVO {
+            return MemberVO(
+                    memberId = member.memberId!!,
+                    nickname = member.nickName
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 개요
- close #56 

## 작업사항
- 메인화면: 모든 상품들에 달린 최신 코멘트를 최대 10개까지 가져오는 api

## 변경로직
- `api/comment`
- `domain/comment`

## 참고사항
- `ProductCommentLike` 작업 후 수정 가능성 있음