### PR TITLE
fix : 코멘트 관련 오류 수정

### DIFF
--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/impl/ProductCommentRepositoryRepositoryImpl.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/repository/impl/ProductCommentRepositoryRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.yapp.cvs.domain.comment.view.ProductCommentDetailView
 import com.yapp.cvs.domain.comment.view.ProductCommentView
 import com.yapp.cvs.domain.comment.vo.ProductCommentSearchVO
 import com.yapp.cvs.domain.like.entity.QMemberProductLikeMapping.memberProductLikeMapping
+import com.yapp.cvs.domain.member.entity.QMember.member
 import com.yapp.cvs.domain.product.entity.QProduct.product
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
 import org.springframework.stereotype.Repository
@@ -44,11 +45,14 @@ class ProductCommentRepositoryRepositoryImpl: QuerydslRepositorySupport(ProductC
             .on(productComment.productCommentId.eq(productCommentRatingSummary.productCommentId))
             .leftJoin(memberProductLikeMapping)
             .on(productComment.memberId.eq(memberProductLikeMapping.memberId).and(productComment.productId.eq(memberProductLikeMapping.productId)))
+            .innerJoin(member)
+            .on(productComment.memberId.eq(member.memberId))
             .where(predicate)
             .orderBy(getOrderBy(productCommentSearchVO.orderBy), productComment.productCommentId.desc())
             .limit(productCommentSearchVO.pageSize)
             .select(Projections.constructor(ProductCommentView::class.java,
                 productComment,
+                member,
                 productCommentRatingSummary.likeCount,
                 memberProductLikeMapping.likeType)
             ).fetch()

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/view/ProductCommentView.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/view/ProductCommentView.kt
@@ -2,9 +2,11 @@ package com.yapp.cvs.domain.comment.view
 
 import com.yapp.cvs.domain.comment.entity.ProductComment
 import com.yapp.cvs.domain.enums.ProductLikeType
+import com.yapp.cvs.domain.member.entity.Member
 
 class ProductCommentView(
     val productComment: ProductComment,
+    val member: Member,
     val likeCount: Long?,
     val productLikeType: ProductLikeType?
 ) {

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentVO.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/comment/vo/ProductCommentVO.kt
@@ -22,11 +22,11 @@ data class ProductCommentVO(
         fun of(productCommentView: ProductCommentView, member: Member, productCommentRatingHistory: ProductCommentRatingHistory?): ProductCommentVO {
             return ProductCommentVO(
                 productCommentId = productCommentView.productComment.productCommentId!!,
-                memberId = member.memberId!!,
-                memberNickName = member.nickName,
+                memberId = productCommentView.member.memberId!!,
+                memberNickName = productCommentView.member.nickName,
                 content = productCommentView.productComment.content,
                 likeCount = productCommentView.likeCount ?: 0,
-                isOwner = productCommentView.productComment.memberId == member.memberId,
+                isOwner = productCommentView.member.memberId == member.memberId,
                 liked = productCommentRatingHistory != null,
                 createdAt = productCommentView.productComment.createdAt,
                 productId = productCommentView.productComment.productId,

--- a/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/like/entity/ProductLikeSummary.kt
+++ b/cvs-domain/src/main/kotlin/com/yapp/cvs/domain/like/entity/ProductLikeSummary.kt
@@ -25,7 +25,7 @@ class ProductLikeSummary(
 
     fun getLikeRatio(): Int {
         if (totalCount == 0L) return 0
-        return ((likeCount / totalCount) * 100).toInt()
+        return (likeCount * 100 / totalCount).toInt()
     }
 
     fun getDislikeRatio(): Int {


### PR DESCRIPTION
## 개요
- close #issueNumber

## 작업사항
- ratio 조회 오류 수정
  - ratio 조회 시 int 로 형변환 되는 문제를 * 100 먼저하는 방식으로 변경
- comment 조회 member 정보 로그인 회원으로만 나오던 오류 수정
  - comment 페이징 조회 시 member innerjoin 해서 같이 가져와서 비교

## 변경로직
- `productComment`
- `productLikeSummary`